### PR TITLE
Fix AdAway BlockList spelling

### DIFF
--- a/ReadME.md
+++ b/ReadME.md
@@ -7,7 +7,7 @@
 ## ADGuard DNS Filter
 https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt
 
-## AdAway Default BlocList
+## AdAway Default BlockList
 https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt
 
 ## OISD Block list small
@@ -21,7 +21,7 @@ https://nsfw.oisd.nl/
 3/ push files in my GitHub
 
 _ADGuard DNS Filter_ : https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt  
-_AdAway Default BlocList_ : https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt  
+_AdAway Default BlockList_ : https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt  
 _OISD Block list small_ : https://adguardteam.github.io/HostlistsRegistry/assets/filter_5.txt  
 _NSFW Oisd_ : https://nsfw.oisd.nl/
 >>>>>>> e643d145d8425f4a7db9e61a72d2680b0f1c049b


### PR DESCRIPTION
## Summary
- fix spelling of "BlockList" in ReadME

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846add7fb2c8327a0821e45f923bb5e